### PR TITLE
Updated the Spoke VPC to fetch the latest Amazon Linux 2003 AMI

### DIFF
--- a/spoke_account/main.tf
+++ b/spoke_account/main.tf
@@ -82,23 +82,13 @@ resource "aws_secretsmanager_secret_version" "spoke_vpc_information" {
 }
 
 # ---------- COMPUTE (NLB + EC2 INSTANCES) ----------
-# Data resource to determine the latest Amazon Linux2 AMI
+# Data resource to determine the latest Amazon Linux Linux 2023 AMI
 data "aws_ami" "amazon_linux" {
   most_recent = true
   owners      = ["amazon"]
-
   filter {
-    name = "name"
-    values = [
-      "amzn-ami-hvm-*-x86_64-gp2",
-    ]
-  }
-
-  filter {
-    name = "owner-alias"
-    values = [
-      "amazon",
-    ]
+    name   = "name"
+    values = ["al2023-ami-2*x86_64"]
   }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
The data resource fails to find the latest Amazon Linux2 AMI (tested in eu-west-1). Amazon Linux 2003 supersedes AL2.

*Description of changes:*
Updated the data resource to fetch the lastest X86_64 version of Amazon Linux 2023 in the region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
