### PR TITLE
Adds logging to FMS on Network Firewall to S3 buckets

### DIFF
--- a/central_account/main.tf
+++ b/central_account/main.tf
@@ -46,6 +46,25 @@ resource "aws_fms_policy" "ingress_policy" {
         routeManagementAction        = "MONITOR"
         routeManagementTargetTypes   = ["InternetGateway"]
       }
+      networkFirewallLoggingConfiguration = {
+        logDestinationConfigs = [
+          {
+            logDestinationType = "S3",
+            logType            = "FLOW",
+            logDestination = {
+              bucketName = "${var.log_destination_s3_arn}"
+            }
+          },
+          {
+            logDestinationType = "S3",
+            logType            = "ALERT",
+            logDestination = {
+              bucketName = "${var.log_destination_s3_arn}"
+            }
+          }
+        ]
+        overrideExistingConfig = false
+      }
     })
   }
 }

--- a/central_account/variables.tf
+++ b/central_account/variables.tf
@@ -44,3 +44,8 @@ variable "secrets_names" {
     spoke_vpc_information = "spoke_vpc_information"
   }
 }
+
+variable "log_destination_s3_arn" {
+  type        = string
+  description = "Network Firewall Log Destination"
+}


### PR DESCRIPTION
*Issue #, if available:*
No issue

*Description of changes:*
As title says, adds logging to FMS on Network Firewall to S3 buckets, with a networkFirewallLoggingConfiguration and logDestinationConfig. This has been relevant for multiple customers that I have implemented FMS at, and is required for FedRAMP High environments etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
